### PR TITLE
Some fix on array transformer

### DIFF
--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
+use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter;
 use Symfony\Component\Form\DataTransformerInterface;
@@ -25,19 +26,21 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 class ModelsToArrayTransformer implements DataTransformerInterface
 {
     /**
-     * @var ChoiceListInterface
+     * @var ModelChoiceList
      */
     protected $choiceList;
 
     /**
-     * @param ChoiceListInterface $choiceList
+     * @param ModelChoiceList|LegacyChoiceListAdapter $choiceList
      */
-    public function __construct(ChoiceListInterface $choiceList)
+    public function __construct($choiceList)
     {
-        if ($choiceList instanceof LegacyChoiceListAdapter) {
+        if ($choiceList instanceof LegacyChoiceListAdapter && $choiceList->getAdaptedList() instanceof ModelChoiceList) {
             $this->choiceList = $choiceList->getAdaptedList();
-        } else {
+        } elseif ($choiceList instanceof ModelChoiceList) {
             $this->choiceList = $choiceList;
+        } else {
+            new \InvalidArgumentException('Argument 1 passed to '.__CLASS__.'::'.__METHOD__.' must be an instance of Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList, instance of '.get_class($choiceList).' given');
         }
     }
 

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
+use Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -30,17 +31,16 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->modelChoiceList = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\ChoiceListInterface')
+        $this->modelChoiceList = $this->getMockBuilder('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->choiceList = $this->getMockBuilder('Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->choiceList->expects($this->once())
-            ->method('getAdaptedList')
-            ->will($this->returnValue($this->modelChoiceList));
+        // Symfony < 2.7 BC
+        if (class_exists('Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter')) {
+            $this->choiceList = new LegacyChoiceListAdapter($this->modelChoiceList);
+        } else {
+            $this->choiceList = $this->modelChoiceList;
+        }
 
         $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 


### PR DESCRIPTION
- More flexible `ModelsToArrayTransformer` constructor for older Symfony versions
- `LegacyChoiceListAdapter` instance instead of mock for test

Please merge this one and squash commit for final PR. :+1: 
